### PR TITLE
Add better instructions on how to generate the bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ func main() {
 
 ### Building / Updating Raylib / Contribution
 If you wish to build and update raylib, the project comes with a useful converter.
-To run the converter, you need the `goimports` tool. It can be installed by running the command `go get golang.org/x/tools/cmd/goimports`
+To run the converter, you need the `goimports` tool. It can be installed by running the command `go get golang.org/x/tools/cmd/goimports`.
 Make sure you update the source files in `raylib/` and update the `raylib-convert/headings.txt` headings (this tells the converter what to export). Once that is done, simply run `./build.sh`.
 
 You can run the converter on Windows by using Git Bash (included with [Git for Windows](https://gitforwindows.org/)).

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ func main() {
 
 ### Building / Updating Raylib / Contribution
 If you wish to build and update raylib, the project comes with a useful converter.
+To run the converter, you need the `goimports` tool. It can be installed by running the command `go get golang.org/x/tools/cmd/goimports`
 Make sure you update the source files in `raylib/` and update the `raylib-convert/headings.txt` headings (this tells the converter what to export). Once that is done, simply run `./build.sh`.
+You can run the converter on Windows by using Git Bash (included with [Git for Windows](https://gitforwindows.org/)).
 
 I am happy for any contributions. This is a big project with over 477 functions! Its likely I have missed something or something doesn't work right for a particular platform (I only test on Windows).
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ func main() {
 If you wish to build and update raylib, the project comes with a useful converter.
 To run the converter, you need the `goimports` tool. It can be installed by running the command `go get golang.org/x/tools/cmd/goimports`
 Make sure you update the source files in `raylib/` and update the `raylib-convert/headings.txt` headings (this tells the converter what to export). Once that is done, simply run `./build.sh`.
+
 You can run the converter on Windows by using Git Bash (included with [Git for Windows](https://gitforwindows.org/)).
 
 I am happy for any contributions. This is a big project with over 477 functions! Its likely I have missed something or something doesn't work right for a particular platform (I only test on Windows).


### PR DESCRIPTION
The instructions for generating the bindings needed clarification about certain things:

- The `goimports` tool is required to generate the bindings.
- The bindings can be generated on Windows using Git Bash.