### PR TITLE
Helper script to update raylib from git upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __debug_bin
 raylib-convert/out
+build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+- "1.13.3"
+
+script: ./update.sh
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
 - "1.13.3"
 
+install: skip
 script: ./update.sh
 
 

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+WORKSPACE=$(pwd)
+SRC=${WORKSPACE}/raylib
+
+mkdir build
+cd build
+
+# Checkout original sources
+# TODO: Allow to pull a specific branch
+git clone https://github.com/raysan5/raylib.git
+cd raylib/src
+git pull
+
+# copy files
+for f in $(find . -type f); do
+				dest="$SRC/$(echo $f | cut -c 3-)"
+				echo "Copy $f -> $dest"
+				cp -f $f $dest
+done
+
+cd $WORKSPACE
+
+# Try to build updated project
+go get golang.org/x/tools/cmd/goimports
+chmod +x build.sh
+./build.sh


### PR DESCRIPTION

Helper script to update raylib from git upstream. 
- Clone raylib repo
- Copies files to the expected location
- Builds the project

Travis could be used for CI builds