### PR TITLE
Added GUI text size and spacing properties

### DIFF
--- a/raylib/raygui.go
+++ b/raylib/raygui.go
@@ -59,8 +59,8 @@ const (
 	GuiPropertyBaseColorNormal
 	GuiPropertyTextColorNormal
 	GuiPropertyBorderColorFocused
-  GuiPropertyTextSize = 16
-  GuiPropertyTextSpacing = 17
+	GuiPropertyTextSize    = 16
+	GuiPropertyTextSpacing = 17
 )
 
 var guiEnabled bool

--- a/raylib/raygui.go
+++ b/raylib/raygui.go
@@ -59,6 +59,7 @@ const (
 	GuiPropertyBaseColorNormal
 	GuiPropertyTextColorNormal
 	GuiPropertyBorderColorFocused
+  GuiPropertyTextSize = 16
 )
 
 var guiEnabled bool

--- a/raylib/raygui.go
+++ b/raylib/raygui.go
@@ -60,6 +60,7 @@ const (
 	GuiPropertyTextColorNormal
 	GuiPropertyBorderColorFocused
   GuiPropertyTextSize = 16
+  GuiPropertyTextSpacing = 17
 )
 
 var guiEnabled bool


### PR DESCRIPTION
I noticed that the bindings lack these two properties from raylib.h, so I added their values.